### PR TITLE
also copy license to nuget package

### DIFF
--- a/Microsoft.Shared.Dna.Json/Microsoft.Shared.Dna.Json.nuspec
+++ b/Microsoft.Shared.Dna.Json/Microsoft.Shared.Dna.Json.nuspec
@@ -26,5 +26,6 @@
     <file src="JsonConstants.cs" target="content\net40\Microsoft.Shared.Dna" />
     <file src="JsonParser.cs" target="content\net40\Microsoft.Shared.Dna" />
     <file src="JsonTokenTypeExtensions.cs" target="content\net40\Microsoft.Shared.Dna" />
+    <file src="..\LICENSE.txt" target="content\net40" />
   </files>
 </package>


### PR DESCRIPTION
Comment header in all source files say:

> See license file in the project root for full license information.

But this license file is missing when pulled through NuGet.

